### PR TITLE
Add validation to remove empty strings from the path split

### DIFF
--- a/betterboto/organizations.py
+++ b/betterboto/organizations.py
@@ -175,7 +175,8 @@ def convert_path_to_ou(self, path):
         root = response.get('Roots')[0]
         return root.get('Id')
     else:
-        parts = path.split("/")
+        # You get the name of the ou back, including /'s
+        parts = list(filter(None, path.split("/"))) 
         parts.reverse()
         parts.pop()
         part_looking_for = parts.pop()


### PR DESCRIPTION
Added a filter to remove empty strings after splitting paths in `convert_path_to_ou` for validation, in case the OU's name includes any slashes.