### PR TITLE
Fix cloudformation helper to work with S3 urls

### DIFF
--- a/betterboto/cloudformation.py
+++ b/betterboto/cloudformation.py
@@ -53,7 +53,7 @@ def create_or_update(self, **kwargs):
             raise e
     else:
         logger.info('Updating: {}'.format(stack_name))
-        change_set_name = get_hash_for_template(kwargs.get('TemplateBody'))
+        change_set_name = get_hash_for_template(kwargs.get('TemplateBody', kwargs.get('TemplateURL')))
         self.create_change_set(
             ChangeSetName=change_set_name,
             ChangeSetType="UPDATE",


### PR DESCRIPTION
Fixes #7 by using either the hash of the body or the URL of the template